### PR TITLE
use 'babel-preset-es2015' instead of node.js es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,9 @@
   "env": {
     "production": {
       "only": [ "src" ],
+      "presets": [
+        "babel-preset-es2015"
+      ],
       "plugins": [
         [ "babel-plugin-unassert" ]
       ]

--- a/benchmark/runner/runBenchmark.js
+++ b/benchmark/runner/runBenchmark.js
@@ -17,7 +17,9 @@ module.exports = (func, target) => {
 
   function runInOfflineAudioContext(api) {
     return (deferred) => {
-      const context = new api.OfflineAudioContext(2, 44100 * 10, 44100);
+      const context = new api.OfflineAudioContext(2, 44100, 44100);
+
+      context._renderingIterations = 65536;
 
       func(context);
 
@@ -27,15 +29,17 @@ module.exports = (func, target) => {
     };
   }
 
-  target.forEach((name) => {
-    const api = requireAPIIfExists(name);
+  if (target) {
+    target.forEach((name) => {
+      const api = requireAPIIfExists(name);
 
-    if (!api || typeof api.OfflineAudioContext !== "function") {
-      return console.log(`api: ${ name } is not found`);
-    }
+      if (!api || typeof api.OfflineAudioContext !== "function") {
+        return console.log(`api: ${ name } is not found`);
+      }
 
-    suite.add(name, runInOfflineAudioContext(api), { defer: true });
-  });
+      suite.add(name, runInOfflineAudioContext(api), { defer: true });
+    });
+  }
 
   suite.add("build", runInOfflineAudioContext(build), { defer: true });
   suite.add("dev", runInOfflineAudioContext(dev), { defer: true });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "build": "npm-run-all build:*",
-    "build:browser": "mkdir -p build && BABEL_ENV=production browserify src -s WebAudioEngine -o build/web-audio-engine.js -t [ babelify --presets [ es2015 ] ]",
+    "build:browser": "mkdir -p build && BABEL_ENV=production browserify src -s WebAudioEngine -o build/web-audio-engine.js -t [ babelify ]",
     "build:to5": "mkdir -p lib && BABEL_ENV=production babel --out-dir=lib src",
     "clean": "rm -rf lib coverage .nyc_output npm-debug.log",
     "cover": "BABEL_ENV=coverage nyc --reporter text --reporter html mocha --require babel-register",


### PR DESCRIPTION
use node.js es2015 (look at "dev")

```
build x 136 ops/sec ±1.45% (77 runs sampled)
dev x 94.16 ops/sec ±1.77% (72 runs sampled)
Fastest is build
```

use "babel-preset-es2015"

```
build x 137 ops/sec ±1.70% (77 runs sampled)
dev x 135 ops/sec ±1.88% (77 runs sampled)
Fastest is build,dev
```

94.16 -> 135 opts