### PR TITLE
Reduce CPU usage for StreamAudioContext.

### DIFF
--- a/src/context/StreamAudioContext.js
+++ b/src/context/StreamAudioContext.js
@@ -4,7 +4,6 @@ const nmap = require("nmap");
 const config = require("../config");
 const BaseAudioContext = require("../api/BaseAudioContext");
 const PCMEncoder = require("../utils/PCMEncoder");
-const setImmediate = require("../utils/setImmediate");
 const { defaults, defineProp } = require("../utils");
 const { toValidSampleRate, toValidBlockSize, toValidNumberOfChannels, toValidBitDepth } = require("../utils");
 const { RUNNING, SUSPENDED, CLOSED } = require("../constants/AudioContextState");
@@ -133,11 +132,11 @@ class StreamAudioContext extends BaseAudioContext {
           }
         }
 
-        setImmediate(renderingProcess);
+        setTimeout(renderingProcess, 100);
       }
     };
     this._isPlaying = true;
-    setImmediate(renderingProcess);
+    setTimeout(renderingProcess, 100);
   }
 
   _suspend() {


### PR DESCRIPTION
I had concerns that the the WAE was taking up 100% of my CPU usage when running. (Chrome's web audio doesn't seem to take up any CPU at all, but it's not nearly as flexible when it comes to audio buffers.)

I looked into the library and twiddled with some timings here. It seems calling setTimeout(0) means this function is being called far too often. I set the timeout all the way up to 1000ms and it doesn't disrupt the audio at all on my computer (probably due to the drain callback), while it does take node's CPU usage from 100% to under 15% usage. Setting it to 100ms seems to have all the benefits of easing off the CPU without the complaints about empty buffers.

(Tested on a mac using `top` in a Terminal window, using npm's `speaker` module as the output.)